### PR TITLE
add default security group for instance

### DIFF
--- a/aws-01/06_ec2.tf
+++ b/aws-01/06_ec2.tf
@@ -9,7 +9,8 @@ resource "aws_instance" "bastion-01" {
   subnet_id = "${aws_subnet.public.id}"
   private_ip = "10.1.1.10"
   associate_public_ip_address = true
-  security_groups = [
+  vpc_security_group_ids = [
+    "${aws_vpc.main.default_security_group_id}",
     "${aws_security_group.front-sg.id}"
   ]
   key_name = "${aws_key_pair.auth.id}"
@@ -25,7 +26,8 @@ resource "aws_instance" "stns-01" {
   subnet_id = "${aws_subnet.private.id}"
   associate_public_ip_address = false
   private_ip = "10.1.2.10"
-  security_groups = [
+  vpc_security_group_ids = [
+    "${aws_vpc.main.default_security_group_id}",
     "${aws_security_group.back-sg.id}"
   ]
   key_name = "${aws_key_pair.auth.id}"


### PR DESCRIPTION
see 
https://www.terraform.io/docs/providers/aws/r/instance.html#vpc_security_group_ids
https://www.terraform.io/docs/providers/aws/r/vpc.html#default_security_group_id
https://docs.aws.amazon.com/ja_jp/AWSEC2/latest/UserGuide/using-network-security.html#default-security-group

マネジメントコンソールでEC2インスタンスの詳細を表示した時、セキュリティグループに default がついてなければ
これでbastion-01とstns-01は接続できるんじゃないかと思うんだけど。
他（Route_tableとか）がどうかは確認できてないので絶対じゃないかも。